### PR TITLE
Updated options so they're automatically added as arguments

### DIFF
--- a/tasks/migrate.js
+++ b/tasks/migrate.js
@@ -27,12 +27,11 @@ module.exports = function (grunt) {
     if (arg2)
       args.push(arg2);
 
-    if (options.verbose)
-      args.push('--verbose');
-
-    if (options.dir)
-      args.push('--migrations-dir=' + options.dir);
-
+    var optionProps = Object.keys(options);
+    optionProps.forEach(function (propName) {
+       if (propName === 'env') return;
+       args.push('--' + propName + '=' + options[propName]);
+    });
 
     if (options.env) {
       spawnOpts.env = process.env;


### PR DESCRIPTION
Breaking change; suggestive update so that options are automatically added as arguments when executing the `db-migrate` task. This would allow for better flexibility.
