### PR TITLE
Updates db-migrate version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "url": "https://github.com/unknownexception/grunt-db-migrate/issues"
   },
   "dependencies": {
-    "db-migrate": ">=0.6.3 <0.10"
+    "db-migrate": "^0.10.2"
   }
 }


### PR DESCRIPTION
I made this change and didn't run into issues.  Thought you might also update since plugin is broken when using against migrations created with newer versions of `db-migrate`.